### PR TITLE
Speed up `SplitEpub.get_split_files()` by using existing `SplitEpub.split_lines` data

### DIFF
--- a/epubsplit.py
+++ b/epubsplit.py
@@ -767,10 +767,15 @@ class SplitEpub:
 
         self.filecache = FileCache(self.get_manifest_items())
 
-        # grab a copy--going to be modifying it.  Doesn't do deep copy.
-        lines = self.get_split_lines()
-        for j in linenums:
-            lines[int(j)]['include']=True
+        # set include flag in split_lines.
+        if not self.split_lines: self.get_split_lines()
+        lines = self.split_lines
+
+        for j in range(len(lines)):
+            if j in set(linenums):
+                lines[j]['include']=True
+            else:
+                lines[j]['include']=False
 
         # loop through finding 'chunks' -- contiguous pieces in the
         # same file.  Each included file is at least one chunk, but if
@@ -781,7 +786,7 @@ class SplitEpub:
         currentfile = None
         start = None
         for line in lines:
-            if 'include' in line:
+            if line['include']:
                 if not inchunk: # start new chunk
                     inchunk = True
                     currentfile = line['href']

--- a/epubsplit.py
+++ b/epubsplit.py
@@ -772,7 +772,7 @@ class SplitEpub:
         lines = self.split_lines
 
         for j in range(len(lines)):
-            if j in set(linenums):
+            if j in set([int(k) for k in linenums]):
                 lines[j]['include']=True
             else:
                 lines[j]['include']=False
@@ -1056,7 +1056,7 @@ class SplitEpub:
         # come back to lines again for TOC because files only has files(gasp-shock!)
         count=1
         for line in self.split_lines:
-            if 'include' in line:
+            if line['include']:
                 # if changed, use only changed values.
                 if line['num'] in changedtocs:
                     line['toc'] = changedtocs[line['num']]


### PR DESCRIPTION
Previously, `SplitEpub.get_split_files()` calls `lines = self.get_split_lines()` which requires parsing through the DOM multiple times. This change will use the existing `SplitEpub.split_lines` and include the lines as needed by the linenums, overwriting the `SplitEpub.split_lines` for each time `SplitEpub.get_split_files()` is called.